### PR TITLE
Fixed four bugs in webservice class

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -427,9 +427,7 @@ class mod_zoom_webservice {
             $data['password'] = $zoom->password;
         }
         if ($zoom->recurring) {
-            $data['recurrence'] = array(
-                'type' => ZOOM_RECURRING_MEETING
-            );
+            $data['type'] = ZOOM_RECURRING_MEETING;
             unset($data['start_time']);
             unset($data['duration']);
         }

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -534,7 +534,7 @@ class mod_zoom_webservice {
             case $this->_is_api_version(2):
                 $url = $zoom->webinar ? 'webinars/'.$zoom->meeting_id : 'meetings/'.
                     $zoom->meeting_id;
-                $this->make_call($url, $this->_make_meeting_data_v2($zoom), 'post');
+                $this->make_call($url, $this->_make_meeting_data_v2($zoom), 'patch');
                 break;
         }
 

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -419,7 +419,8 @@ class mod_zoom_webservice {
                 'host_video' => $zoom->option_host_video ? true : false,
                 'participant_video' => $zoom->option_participants_video ? true : false,
                 'join_before_host' => $zoom->option_jbh ? true : false,
-                'audio' => $zoom->option_audio ? true : false
+                'audio' => $zoom->option_audio ? true : false,
+                'alternative_hosts' => $zoom->option_alternative_hosts
             )
         );
         if (isset($CFG->timezone) && !empty($CFG->timezone)) {

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -380,21 +380,18 @@ class mod_zoom_webservice {
                 }
                 break;
             case $this->_is_api_version(2):
-                $users_list = $this->list_users();
-                if (!empty($users_list) && isset($users_list->users) &&
-                        !empty($users_list->users) && is_array($users_list->users)) {
-                    foreach ($users_list->users as $apiuser) {
-                        if ($apiuser->email == $email) {
-                            $apiuser->settings = $this->_get_user_settings($apiuser->id);
-                            $apiuser->enable_webinar = $apiuser->settings->feature->webinar;
-                            if ($email == $USER->email) {
-                                $this->current_user = $apiuser;
-                            }
-                            $this->lastresponse = $apiuser;
-                            return $apiuser;
-                        }
+                $url = 'users/'.$email;
+                try {
+                    $user = $this -> make_call($url);
+                }catch (moodle_exception $e) {
+                    require_once($CFG->dirroot.'/mod/ncmzoom/lib.php');
+                    if (!zoom_is_user_not_found_error($e->getMessage())) {
+                        return false;
                     }
                 }
+                if(empty(!$user)){
+                    return true;
+                } 
                 break;
         }
 


### PR DESCRIPTION
Hi Igor,

I fixed following four issues in webservice class.
1. Recurrence meeting didn't work.  ZOOM_RECURRING_MEETING should be directly assign into request object as a type property ( $data['type'] = ZOOM_RECURRING_MEETING;). 
2.  Updated the http method in meeting update to 'PATCH'. It is not 'POST' in API version 2 (https://zoom.github.io/api/#update-a-meeting)
3.  In Zoom API version 2 'alternative host' has moved inside settings. Therefore we need that in '_make_meeting_data_v2' method.
4.  There is an error in 'user_getbyemail' method. It is used get all the users as a list using 'users/' API call. However this returns only 30 records bydefault and 300 maximum. So this is not correct way to get user by email address. We can use this 'https://api.zoom.us/v2/users/{userId}' instead of that.

Dasu